### PR TITLE
Skip person if UniqueIdentification is an empty string

### DIFF
--- a/src/Person/PersonsToAccounts.php
+++ b/src/Person/PersonsToAccounts.php
@@ -53,6 +53,12 @@ class PersonsToAccounts
 
     private function getUserID(Person $person): ?int
     {
+
+        $uniqueId = $person->getUniqueIdentification();
+        if ($uniqueId === "") {
+            return null;
+         }
+
         switch (true) {
             case ($person instanceof UserIdPerson):
                 return (int) $person->getUniqueIdentification();


### PR DESCRIPTION
- Added logic to skip processing a person when UniqueIdentification is an empty string.
- Ensures that blank lines (i.e., empty UniqueIdentification) are not processed.
-  Without this check, the first person returned from the SQL query might be incorrectly enrolled in the course due to a newline being interpreted as empty string.
