### PR TITLE
Check run modes before setting

### DIFF
--- a/src/Provider/Tool/StandardWorkflowToolProvider.php
+++ b/src/Provider/Tool/StandardWorkflowToolProvider.php
@@ -85,7 +85,16 @@ class StandardWorkflowToolProvider implements WorkflowToolProvider
             )
         );
 
-        $tool_activated = $this->container->config()->general()->showInfoTool();
+	$tool_activated = $this->container->config()->general()->showInfoTool();
+
+        $run_modes = $this->container->objectModeRepository()->getRunModes(
+                    $context->getCurrentRefId(),
+                    $this->workflow_container);
+        if (!$run_modes)
+        {
+            $tool_activated = null;
+        }
+
 
         if (($config_data = $this->container->toolObjectConfigRepository()->get(
             $context->getCurrentRefId(),


### PR DESCRIPTION
Set  to null only if getRunModes() returns empty or null otherwise the members tab won't open if run_modes not set.